### PR TITLE
Give to Attribute the ownership of data

### DIFF
--- a/pkcs11/src/new/functions/decryption.rs
+++ b/pkcs11/src/new/functions/decryption.rs
@@ -14,7 +14,7 @@ impl Pkcs11 {
         session: &Session,
         mechanism: Mechanism,
         key: ObjectHandle,
-        encrypted_data: &mut [u8],
+        encrypted_data: &[u8],
     ) -> Result<Vec<u8>> {
         let mut mechanism: CK_MECHANISM = mechanism.try_into()?;
         let mut data_len = 0;
@@ -32,7 +32,8 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Decrypt)(
                 session.handle(),
-                encrypted_data.as_mut_ptr(),
+                // C_Decrypt should not modify this buffer
+                encrypted_data.as_ptr() as *mut u8,
                 encrypted_data.len().try_into()?,
                 std::ptr::null_mut(),
                 &mut data_len,
@@ -45,7 +46,7 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Decrypt)(
                 session.handle(),
-                encrypted_data.as_mut_ptr(),
+                encrypted_data.as_ptr() as *mut u8,
                 encrypted_data.len().try_into()?,
                 data.as_mut_ptr(),
                 &mut data_len,

--- a/pkcs11/src/new/functions/encryption.rs
+++ b/pkcs11/src/new/functions/encryption.rs
@@ -14,7 +14,7 @@ impl Pkcs11 {
         session: &Session,
         mechanism: Mechanism,
         key: ObjectHandle,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<Vec<u8>> {
         let mut mechanism: CK_MECHANISM = mechanism.try_into()?;
         let mut encrypted_data_len = 0;
@@ -32,7 +32,7 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Encrypt)(
                 session.handle(),
-                data.as_mut_ptr(),
+                data.as_ptr() as *mut u8,
                 data.len().try_into()?,
                 std::ptr::null_mut(),
                 &mut encrypted_data_len,
@@ -45,7 +45,7 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Encrypt)(
                 session.handle(),
-                data.as_mut_ptr(),
+                data.as_ptr() as *mut u8,
                 data.len().try_into()?,
                 encrypted_data.as_mut_ptr(),
                 &mut encrypted_data_len,

--- a/pkcs11/src/new/functions/key_management.rs
+++ b/pkcs11/src/new/functions/key_management.rs
@@ -13,18 +13,14 @@ impl Pkcs11 {
         &self,
         session: &Session,
         mechanism: Mechanism,
-        pub_key_template: &mut [Attribute],
-        priv_key_template: &mut [Attribute],
+        pub_key_template: &[Attribute],
+        priv_key_template: &[Attribute],
     ) -> Result<(ObjectHandle, ObjectHandle)> {
         let mut mechanism: CK_MECHANISM = mechanism.try_into()?;
-        let mut pub_key_template: Vec<CK_ATTRIBUTE> = pub_key_template
-            .iter_mut()
-            .map(|attr| attr.into())
-            .collect();
-        let mut priv_key_template: Vec<CK_ATTRIBUTE> = priv_key_template
-            .iter_mut()
-            .map(|attr| attr.into())
-            .collect();
+        let mut pub_key_template: Vec<CK_ATTRIBUTE> =
+            pub_key_template.iter().map(|attr| attr.into()).collect();
+        let mut priv_key_template: Vec<CK_ATTRIBUTE> =
+            priv_key_template.iter().map(|attr| attr.into()).collect();
         let mut pub_handle = 0;
         let mut priv_handle = 0;
         unsafe {
@@ -51,11 +47,11 @@ impl Pkcs11 {
         &self,
         session: Session,
         mechanism: Mechanism,
-        key_template: &mut [Attribute],
+        key_template: &[Attribute],
     ) -> Result<ObjectHandle> {
         let mut mechanism: CK_MECHANISM = mechanism.try_into()?;
         let mut key_template: Vec<CK_ATTRIBUTE> =
-            key_template.iter_mut().map(|attr| attr.into()).collect();
+            key_template.iter().map(|attr| attr.into()).collect();
         let mut handle = 0;
         unsafe {
             Rv::from(get_pkcs11!(self, C_GenerateKey)(
@@ -86,8 +82,8 @@ impl Pkcs11 {
         _session: Session,
         _mechanism: Mechanism,
         _unwrapping_key: ObjectHandle,
-        _wrapped_key: &mut [u8],
-        _wrapped_key_template: &mut [Attribute],
+        _wrapped_key: &[u8],
+        _wrapped_key_template: &[Attribute],
     ) -> Result<ObjectHandle> {
         Err(Error::NotSupported)
     }
@@ -97,7 +93,7 @@ impl Pkcs11 {
         _session: Session,
         _mechanism: Mechanism,
         _base_key: ObjectHandle,
-        _derived_key_template: &mut [Attribute],
+        _derived_key_template: &[Attribute],
     ) -> Result<ObjectHandle> {
         Err(Error::NotSupported)
     }

--- a/pkcs11/src/new/functions/signing_macing.rs
+++ b/pkcs11/src/new/functions/signing_macing.rs
@@ -14,7 +14,7 @@ impl Pkcs11 {
         session: &Session,
         mechanism: Mechanism,
         key: ObjectHandle,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<Vec<u8>> {
         let mut mechanism: CK_MECHANISM = mechanism.try_into()?;
         let mut signature_len = 0;
@@ -32,7 +32,7 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Sign)(
                 session.handle(),
-                data.as_mut_ptr(),
+                data.as_ptr() as *mut u8,
                 data.len().try_into()?,
                 std::ptr::null_mut(),
                 &mut signature_len,
@@ -46,7 +46,7 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Sign)(
                 session.handle(),
-                data.as_mut_ptr(),
+                data.as_ptr() as *mut u8,
                 data.len().try_into()?,
                 signature.as_mut_ptr(),
                 &mut signature_len,
@@ -64,8 +64,8 @@ impl Pkcs11 {
         session: &Session,
         mechanism: Mechanism,
         key: ObjectHandle,
-        data: &mut [u8],
-        signature: &mut [u8],
+        data: &[u8],
+        signature: &[u8],
     ) -> Result<()> {
         let mut mechanism: CK_MECHANISM = mechanism.try_into()?;
 
@@ -81,9 +81,9 @@ impl Pkcs11 {
         unsafe {
             Rv::from(get_pkcs11!(self, C_Verify)(
                 session.handle(),
-                data.as_mut_ptr(),
+                data.as_ptr() as *mut u8,
                 data.len().try_into()?,
-                signature.as_mut_ptr(),
+                signature.as_ptr() as *mut u8,
                 signature.len().try_into()?,
             ))
             .into_result()

--- a/pkcs11/src/new/types/object.rs
+++ b/pkcs11/src/new/types/object.rs
@@ -265,9 +265,11 @@ impl From<&Attribute> for CK_ATTRIBUTE {
         Self {
             type_: attribute.attribute_type().into(),
             pValue: attribute.ptr(),
-            // Truncation from usize to CK_ULONG not checked
-            // Should be fine in most cases.
-            ulValueLen: attribute.len() as CK_ULONG,
+            // The panic should only happen if there is a bug.
+            ulValueLen: attribute
+                .len()
+                .try_into()
+                .expect("Can not convert the attribute length value (usize) to a CK_ULONG."),
         }
     }
 }

--- a/pkcs11/src/new/types/object.rs
+++ b/pkcs11/src/new/types/object.rs
@@ -1,8 +1,14 @@
+use crate::new::Error;
+use log::error;
 use pkcs11_sys::*;
+use std::convert::TryFrom;
 use std::convert::TryInto;
+use std::ffi::c_void;
+use std::pin::Pin;
 
 #[derive(Debug, Copy, Clone)]
 pub enum AttributeType {
+    AllowedMechanisms,
     Base,
     Class,
     Copyable,
@@ -10,11 +16,12 @@ pub enum AttributeType {
     Derive,
     Encrypt,
     Extractable,
+    Id,
     KeyType,
     Label,
     Modifiable,
-    ModulusBits,
     Modulus,
+    ModulusBits,
     Prime,
     Private,
     PublicExponent,
@@ -33,6 +40,7 @@ pub enum AttributeType {
 impl From<AttributeType> for CK_ATTRIBUTE_TYPE {
     fn from(attribute_type: AttributeType) -> Self {
         match attribute_type {
+            AttributeType::AllowedMechanisms => CKA_ALLOWED_MECHANISMS,
             AttributeType::Base => CKA_BASE,
             AttributeType::Class => CKA_CLASS,
             AttributeType::Copyable => CKA_COPYABLE,
@@ -40,11 +48,12 @@ impl From<AttributeType> for CK_ATTRIBUTE_TYPE {
             AttributeType::Derive => CKA_DERIVE,
             AttributeType::Encrypt => CKA_ENCRYPT,
             AttributeType::Extractable => CKA_EXTRACTABLE,
+            AttributeType::Id => CKA_ID,
             AttributeType::KeyType => CKA_KEY_TYPE,
             AttributeType::Label => CKA_LABEL,
             AttributeType::Modifiable => CKA_MODIFIABLE,
-            AttributeType::ModulusBits => CKA_MODULUS_BITS,
             AttributeType::Modulus => CKA_MODULUS,
+            AttributeType::ModulusBits => CKA_MODULUS_BITS,
             AttributeType::Prime => CKA_PRIME,
             AttributeType::Private => CKA_PRIVATE,
             AttributeType::PublicExponent => CKA_PUBLIC_EXPONENT,
@@ -62,38 +71,81 @@ impl From<AttributeType> for CK_ATTRIBUTE_TYPE {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub enum Attribute<'a> {
-    Base(&'a mut CK_BYTE),
-    Class(&'a mut CK_OBJECT_CLASS),
-    Copyable(&'a mut CK_BBOOL),
-    Decrypt(&'a mut CK_BBOOL),
-    Derive(&'a mut CK_BBOOL),
-    Encrypt(&'a mut CK_BBOOL),
-    Extractable(&'a mut CK_BBOOL),
-    KeyType(&'a mut CK_KEY_TYPE),
-    Label(&'a mut [CK_UTF8CHAR]),
-    Modifiable(&'a mut CK_BBOOL),
-    ModulusBits(&'a mut CK_ULONG),
-    Modulus(&'a mut [CK_BYTE]),
-    Prime(&'a mut [CK_BYTE]),
-    Private(&'a mut CK_BBOOL),
-    PublicExponent(&'a mut [CK_BYTE]),
-    Sensitive(&'a mut CK_BBOOL),
-    Sign(&'a mut CK_BBOOL),
-    SignRecover(&'a mut CK_BBOOL),
-    Token(&'a mut CK_BBOOL),
-    Unwrap(&'a mut CK_BBOOL),
-    Value(&'a mut [u8]),
-    ValueLen(&'a mut CK_ULONG),
-    Verify(&'a mut CK_BBOOL),
-    VerifyRecover(&'a mut CK_BBOOL),
-    Wrap(&'a mut CK_BBOOL),
+impl TryFrom<CK_ATTRIBUTE_TYPE> for AttributeType {
+    type Error = Error;
+
+    fn try_from(attribute_type: CK_ATTRIBUTE_TYPE) -> Result<Self, Error> {
+        match attribute_type {
+            CKA_ALLOWED_MECHANISMS => Ok(AttributeType::AllowedMechanisms),
+            CKA_BASE => Ok(AttributeType::Base),
+            CKA_CLASS => Ok(AttributeType::Class),
+            CKA_COPYABLE => Ok(AttributeType::Copyable),
+            CKA_DECRYPT => Ok(AttributeType::Decrypt),
+            CKA_DERIVE => Ok(AttributeType::Derive),
+            CKA_ENCRYPT => Ok(AttributeType::Encrypt),
+            CKA_EXTRACTABLE => Ok(AttributeType::Extractable),
+            CKA_ID => Ok(AttributeType::Id),
+            CKA_KEY_TYPE => Ok(AttributeType::KeyType),
+            CKA_LABEL => Ok(AttributeType::Label),
+            CKA_MODIFIABLE => Ok(AttributeType::Modifiable),
+            CKA_MODULUS => Ok(AttributeType::Modulus),
+            CKA_MODULUS_BITS => Ok(AttributeType::ModulusBits),
+            CKA_PRIME => Ok(AttributeType::Prime),
+            CKA_PRIVATE => Ok(AttributeType::Private),
+            CKA_PUBLIC_EXPONENT => Ok(AttributeType::PublicExponent),
+            CKA_SENSITIVE => Ok(AttributeType::Sensitive),
+            CKA_SIGN => Ok(AttributeType::Sign),
+            CKA_SIGN_RECOVER => Ok(AttributeType::SignRecover),
+            CKA_TOKEN => Ok(AttributeType::Token),
+            CKA_UNWRAP => Ok(AttributeType::Unwrap),
+            CKA_VALUE => Ok(AttributeType::Value),
+            CKA_VALUE_LEN => Ok(AttributeType::ValueLen),
+            CKA_VERIFY => Ok(AttributeType::Verify),
+            CKA_VERIFY_RECOVER => Ok(AttributeType::VerifyRecover),
+            CKA_WRAP => Ok(AttributeType::Wrap),
+            attr_type => {
+                error!("Attribute type {} not supported.", attr_type);
+                Err(Error::NotSupported)
+            }
+        }
+    }
 }
 
-impl Attribute<'_> {
+#[derive(Debug)]
+pub enum Attribute {
+    AllowedMechanisms(Pin<Vec<CK_MECHANISM_TYPE>>),
+    Base(Pin<Vec<u8>>),
+    Class(Pin<Box<CK_OBJECT_CLASS>>),
+    Copyable(Pin<Box<CK_BBOOL>>),
+    Decrypt(Pin<Box<CK_BBOOL>>),
+    Derive(Pin<Box<CK_BBOOL>>),
+    Encrypt(Pin<Box<CK_BBOOL>>),
+    Extractable(Pin<Box<CK_BBOOL>>),
+    Id(Pin<Vec<u8>>),
+    KeyType(Pin<Box<CK_KEY_TYPE>>),
+    Label(Pin<Vec<u8>>),
+    Modifiable(Pin<Box<CK_BBOOL>>),
+    Modulus(Pin<Vec<u8>>),
+    ModulusBits(Pin<Box<CK_ULONG>>),
+    Prime(Pin<Vec<u8>>),
+    Private(Pin<Box<CK_BBOOL>>),
+    PublicExponent(Pin<Vec<u8>>),
+    Sensitive(Pin<Box<CK_BBOOL>>),
+    Sign(Pin<Box<CK_BBOOL>>),
+    SignRecover(Pin<Box<CK_BBOOL>>),
+    Token(Pin<Box<CK_BBOOL>>),
+    Unwrap(Pin<Box<CK_BBOOL>>),
+    Value(Pin<Vec<u8>>),
+    ValueLen(Pin<Box<CK_ULONG>>),
+    Verify(Pin<Box<CK_BBOOL>>),
+    VerifyRecover(Pin<Box<CK_BBOOL>>),
+    Wrap(Pin<Box<CK_BBOOL>>),
+}
+
+impl Attribute {
     pub fn attribute_type(&self) -> AttributeType {
         match self {
+            Attribute::AllowedMechanisms(_) => AttributeType::AllowedMechanisms,
             Attribute::Base(_) => AttributeType::Base,
             Attribute::Class(_) => AttributeType::Class,
             Attribute::Copyable(_) => AttributeType::Copyable,
@@ -101,11 +153,12 @@ impl Attribute<'_> {
             Attribute::Derive(_) => AttributeType::Derive,
             Attribute::Encrypt(_) => AttributeType::Encrypt,
             Attribute::Extractable(_) => AttributeType::Extractable,
+            Attribute::Id(_) => AttributeType::Id,
             Attribute::KeyType(_) => AttributeType::KeyType,
             Attribute::Label(_) => AttributeType::Label,
             Attribute::Modifiable(_) => AttributeType::Modifiable,
-            Attribute::ModulusBits(_) => AttributeType::ModulusBits,
             Attribute::Modulus(_) => AttributeType::Modulus,
+            Attribute::ModulusBits(_) => AttributeType::ModulusBits,
             Attribute::Prime(_) => AttributeType::Prime,
             Attribute::Private(_) => AttributeType::Private,
             Attribute::PublicExponent(_) => AttributeType::PublicExponent,
@@ -123,8 +176,8 @@ impl Attribute<'_> {
     }
 
     /// Returns the length in bytes of the objects contained by this CkAttribute.
-    fn len(&self) -> CK_ULONG {
-        let len = match self {
+    fn len(&self) -> usize {
+        match self {
             Attribute::Copyable(_)
             | Attribute::Decrypt(_)
             | Attribute::Derive(_)
@@ -140,23 +193,34 @@ impl Attribute<'_> {
             | Attribute::Verify(_)
             | Attribute::VerifyRecover(_)
             | Attribute::Wrap(_) => std::mem::size_of::<CK_BBOOL>(),
-            Attribute::Base(_) => std::mem::size_of::<CK_BYTE>(),
+            Attribute::Base(_) => 1,
             Attribute::Class(_) => std::mem::size_of::<CK_OBJECT_CLASS>(),
             Attribute::KeyType(_) => std::mem::size_of::<CK_KEY_TYPE>(),
             Attribute::Label(label) => std::mem::size_of::<CK_UTF8CHAR>() * label.len(),
             Attribute::ModulusBits(_) => std::mem::size_of::<CK_ULONG>(),
-            Attribute::Prime(bytes) => std::mem::size_of::<CK_BYTE>() * bytes.len(),
-            Attribute::PublicExponent(bytes) => std::mem::size_of::<CK_BYTE>() * bytes.len(),
-            Attribute::Modulus(bytes) => std::mem::size_of::<CK_BYTE>() * bytes.len(),
+            Attribute::Prime(bytes) => bytes.len(),
+            Attribute::PublicExponent(bytes) => bytes.len(),
+            Attribute::Modulus(bytes) => bytes.len(),
             Attribute::Value(bytes) => std::mem::size_of::<u8>() * bytes.len(),
             Attribute::ValueLen(_) => std::mem::size_of::<CK_ULONG>(),
-        };
-        len.try_into().unwrap()
+            Attribute::Id(bytes) => bytes.len(),
+            Attribute::AllowedMechanisms(mechanisms) => {
+                std::mem::size_of::<CK_MECHANISM_TYPE>() * mechanisms.len()
+            }
+        }
     }
 
     /// Returns a CK_VOID_PTR pointing to the object contained by this CkAttribute.
-    fn ptr(&mut self) -> CK_VOID_PTR {
+    ///
+    /// Casting from an immutable reference to a mutable pointer is kind of unsafe but the
+    /// Attribute structure will only be used with PKCS11 functions that do not modify the template
+    /// given.
+    /// The C_GetAttributeValue function, which is the only one that modifies the template given,
+    /// will not use Attribute parameters but return them
+    /// directly to the caller.
+    fn ptr(&self) -> *mut c_void {
         match self {
+            // CK_BBOOL
             Attribute::Copyable(b)
             | Attribute::Decrypt(b)
             | Attribute::Derive(b)
@@ -171,27 +235,133 @@ impl Attribute<'_> {
             | Attribute::Unwrap(b)
             | Attribute::Verify(b)
             | Attribute::VerifyRecover(b)
-            | Attribute::Wrap(b) => *b as *mut _ as CK_VOID_PTR,
-            Attribute::Base(byte) => *byte as *mut _ as CK_VOID_PTR,
-            Attribute::Class(object_class) => *object_class as CK_OBJECT_CLASS_PTR as CK_VOID_PTR,
-            Attribute::KeyType(key_type) => *key_type as *mut _ as CK_VOID_PTR,
-            Attribute::Label(label) => label.as_ptr() as CK_VOID_PTR,
-            Attribute::ModulusBits(bits) => *bits as *mut _ as CK_VOID_PTR,
-            Attribute::Prime(bytes) => bytes.as_ptr() as CK_VOID_PTR,
-            Attribute::PublicExponent(bytes) => bytes.as_ptr() as CK_VOID_PTR,
-            Attribute::Modulus(bytes) => bytes.as_ptr() as CK_VOID_PTR,
-            Attribute::Value(value) => value.as_ptr() as CK_VOID_PTR,
-            Attribute::ValueLen(len) => *len as *mut _ as CK_VOID_PTR,
+            | Attribute::Wrap(b) => b.as_ref().get_ref() as *const _ as *mut c_void,
+            // CK_ULONG
+            Attribute::ModulusBits(val) | Attribute::ValueLen(val) => {
+                val.as_ref().get_ref() as *const _ as *mut c_void
+            }
+            // Vec<u8>
+            Attribute::Base(bytes)
+            | Attribute::Label(bytes)
+            | Attribute::Prime(bytes)
+            | Attribute::PublicExponent(bytes)
+            | Attribute::Modulus(bytes)
+            | Attribute::Value(bytes)
+            | Attribute::Id(bytes) => bytes.as_ptr() as *mut c_void,
+            // Unique types
+            Attribute::Class(object_class) => {
+                object_class.as_ref().get_ref() as *const _ as *mut c_void
+            }
+            Attribute::KeyType(key_type) => key_type.as_ref().get_ref() as *const _ as *mut c_void,
+            Attribute::AllowedMechanisms(mechanisms) => {
+                mechanisms.as_ref().get_ref() as *const _ as *mut c_void
+            }
         }
     }
 }
 
-impl From<&mut Attribute<'_>> for CK_ATTRIBUTE {
-    fn from(attribute: &mut Attribute) -> Self {
+impl From<&Attribute> for CK_ATTRIBUTE {
+    fn from(attribute: &Attribute) -> Self {
         Self {
             type_: attribute.attribute_type().into(),
             pValue: attribute.ptr(),
-            ulValueLen: attribute.len(),
+            // Truncation from usize to CK_ULONG not checked
+            // Should be fine in most cases.
+            ulValueLen: attribute.len() as CK_ULONG,
+        }
+    }
+}
+
+impl TryFrom<CK_ATTRIBUTE> for Attribute {
+    type Error = Error;
+
+    fn try_from(attribute: CK_ATTRIBUTE) -> Result<Self, Error> {
+        let attr_type = AttributeType::try_from(attribute.type_)?;
+        // Cast from c_void to u8
+        let val = unsafe {
+            std::slice::from_raw_parts(
+                attribute.pValue as *const u8,
+                attribute.ulValueLen.try_into()?,
+            )
+        };
+        match attr_type {
+            // CK_BBOOL
+            AttributeType::Copyable => Ok(Attribute::Copyable(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Decrypt => Ok(Attribute::Decrypt(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Derive => Ok(Attribute::Derive(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Encrypt => Ok(Attribute::Encrypt(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Extractable => Ok(Attribute::Extractable(Box::pin(
+                CK_BBOOL::from_ne_bytes(val[0..1].try_into()?),
+            ))),
+            AttributeType::Modifiable => Ok(Attribute::Modifiable(Box::pin(
+                CK_BBOOL::from_ne_bytes(val[0..1].try_into()?),
+            ))),
+            AttributeType::Private => Ok(Attribute::Private(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Sensitive => Ok(Attribute::Sensitive(Box::pin(
+                CK_BBOOL::from_ne_bytes(val[0..1].try_into()?),
+            ))),
+            AttributeType::Sign => Ok(Attribute::Sign(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::SignRecover => Ok(Attribute::SignRecover(Box::pin(
+                CK_BBOOL::from_ne_bytes(val[0..1].try_into()?),
+            ))),
+            AttributeType::Token => Ok(Attribute::Token(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Unwrap => Ok(Attribute::Unwrap(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::Verify => Ok(Attribute::Verify(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            AttributeType::VerifyRecover => Ok(Attribute::VerifyRecover(Box::pin(
+                CK_BBOOL::from_ne_bytes(val[0..1].try_into()?),
+            ))),
+            AttributeType::Wrap => Ok(Attribute::Wrap(Box::pin(CK_BBOOL::from_ne_bytes(
+                val[0..1].try_into()?,
+            )))),
+            // CK_ULONG
+            AttributeType::ModulusBits => Ok(Attribute::ModulusBits(Box::pin(
+                CK_ULONG::from_ne_bytes(val[0..7].try_into()?),
+            ))),
+            AttributeType::ValueLen => Ok(Attribute::ValueLen(Box::pin(CK_ULONG::from_ne_bytes(
+                val[0..7].try_into()?,
+            )))),
+            // Vec<u8>
+            AttributeType::Base => Ok(Attribute::Base(Pin::new(val.to_vec()))),
+            AttributeType::Label => Ok(Attribute::Label(Pin::new(val.to_vec()))),
+            AttributeType::Prime => Ok(Attribute::Prime(Pin::new(val.to_vec()))),
+            AttributeType::PublicExponent => Ok(Attribute::PublicExponent(Pin::new(val.to_vec()))),
+            AttributeType::Modulus => Ok(Attribute::Modulus(Pin::new(val.to_vec()))),
+            AttributeType::Value => Ok(Attribute::Value(Pin::new(val.to_vec()))),
+            AttributeType::Id => Ok(Attribute::Id(Pin::new(val.to_vec()))),
+            // Unique types
+            AttributeType::Class => Ok(Attribute::Class(Box::pin(CK_OBJECT_CLASS::from_ne_bytes(
+                val[0..7].try_into()?,
+            )))),
+            AttributeType::KeyType => Ok(Attribute::KeyType(Box::pin(CK_KEY_TYPE::from_ne_bytes(
+                val[0..7].try_into()?,
+            )))),
+            AttributeType::AllowedMechanisms => {
+                let val = unsafe {
+                    std::slice::from_raw_parts(
+                        attribute.pValue as *const CK_MECHANISM_TYPE,
+                        attribute.ulValueLen.try_into()?,
+                    )
+                };
+                Ok(Attribute::AllowedMechanisms(Pin::new(val.to_vec())))
+            }
         }
     }
 }


### PR DESCRIPTION
Use Pin to make sure the address of the data contained in the attribute
is not changed after it is given to the C implementation.
Modify the signature to remove the mut when not needed.
Modify the get_attribute_value to return owned data in the Attribute.