### PR TITLE
Implement operations on Session

### DIFF
--- a/pkcs11/src/new/functions/general_purpose.rs
+++ b/pkcs11/src/new/functions/general_purpose.rs
@@ -19,10 +19,11 @@ impl Pkcs11 {
         }
     }
 
-    /// # Safety
-    ///
-    /// TODO
-    pub unsafe fn finalize(&self) -> Result<()> {
-        Rv::from(get_pkcs11!(self, C_Finalize)(ptr::null_mut())).into_result()
+    pub(crate) fn finalize_private(&self) -> Result<()> {
+        // Safe because Session contain a reference to self so that this function can not be called
+        // while there are live Session instances.
+        unsafe { Rv::from(get_pkcs11!(self, C_Finalize)(ptr::null_mut())).into_result() }
     }
+
+    pub fn finalize(self) {}
 }

--- a/pkcs11/src/new/functions/key_management.rs
+++ b/pkcs11/src/new/functions/key_management.rs
@@ -3,15 +3,13 @@ use crate::new::types::function::Rv;
 use crate::new::types::mechanism::Mechanism;
 use crate::new::types::object::{Attribute, ObjectHandle};
 use crate::new::types::session::Session;
-use crate::new::Pkcs11;
 use crate::new::{Error, Result};
 use pkcs11_sys::{CK_ATTRIBUTE, CK_MECHANISM, CK_MECHANISM_PTR};
 use std::convert::TryInto;
 
-impl Pkcs11 {
+impl<'a> Session<'a> {
     pub fn generate_key_pair(
         &self,
-        session: &Session,
         mechanism: &Mechanism,
         pub_key_template: &[Attribute],
         priv_key_template: &[Attribute],
@@ -24,8 +22,8 @@ impl Pkcs11 {
         let mut pub_handle = 0;
         let mut priv_handle = 0;
         unsafe {
-            Rv::from(get_pkcs11!(self, C_GenerateKeyPair)(
-                session.handle(),
+            Rv::from(get_pkcs11!(self.client(), C_GenerateKeyPair)(
+                self.handle(),
                 &mut mechanism as CK_MECHANISM_PTR,
                 pub_key_template.as_mut_ptr(),
                 pub_key_template.len().try_into()?,
@@ -45,7 +43,6 @@ impl Pkcs11 {
 
     pub fn generate_key(
         &self,
-        session: Session,
         mechanism: &Mechanism,
         key_template: &[Attribute],
     ) -> Result<ObjectHandle> {
@@ -54,8 +51,8 @@ impl Pkcs11 {
             key_template.iter().map(|attr| attr.into()).collect();
         let mut handle = 0;
         unsafe {
-            Rv::from(get_pkcs11!(self, C_GenerateKey)(
-                session.handle(),
+            Rv::from(get_pkcs11!(self.client(), C_GenerateKey)(
+                self.handle(),
                 &mut mechanism as CK_MECHANISM_PTR,
                 key_template.as_mut_ptr(),
                 key_template.len().try_into()?,
@@ -69,7 +66,6 @@ impl Pkcs11 {
 
     pub fn wrap_key(
         &self,
-        _session: Session,
         _mechanism: &Mechanism,
         _wrapping_key: ObjectHandle,
         _wrapped_key: ObjectHandle,
@@ -79,7 +75,6 @@ impl Pkcs11 {
 
     pub fn unwrap_key(
         &self,
-        _session: Session,
         _mechanism: &Mechanism,
         _unwrapping_key: ObjectHandle,
         _wrapped_key: &[u8],
@@ -90,7 +85,6 @@ impl Pkcs11 {
 
     pub fn derive_key(
         &self,
-        _session: Session,
         _mechanism: &Mechanism,
         _base_key: ObjectHandle,
         _derived_key_template: &[Attribute],

--- a/pkcs11/src/new/functions/session_management.rs
+++ b/pkcs11/src/new/functions/session_management.rs
@@ -26,19 +26,21 @@ impl Pkcs11 {
 
         Ok(Session::new(session_handle, &self))
     }
+}
 
-    pub fn close_session(&self, _session: Session) {}
+impl<'a> Session<'a> {
+    pub fn close(&self) {}
 
-    pub(crate) fn close_session_private(&self, session: &Session) -> Result<()> {
-        unsafe { Rv::from(get_pkcs11!(self, C_CloseSession)(session.handle())).into_result() }
+    pub(crate) fn close_private(&self) -> Result<()> {
+        unsafe { Rv::from(get_pkcs11!(self.client(), C_CloseSession)(self.handle())).into_result() }
     }
 
-    pub fn login(&self, session: &Session, user_type: UserType, pin: &str) -> Result<()> {
+    pub fn login(&self, user_type: UserType, pin: &str) -> Result<()> {
         //TODO: zeroize after
         let mut pin = CString::new(pin)?.into_bytes();
         unsafe {
-            Rv::from(get_pkcs11!(self, C_Login)(
-                session.handle(),
+            Rv::from(get_pkcs11!(self.client(), C_Login)(
+                self.handle(),
                 user_type.into(),
                 pin.as_mut_ptr(),
                 pin.len().try_into()?,
@@ -47,7 +49,7 @@ impl Pkcs11 {
         }
     }
 
-    pub fn logout(&self, session: &Session) -> Result<()> {
-        unsafe { Rv::from(get_pkcs11!(self, C_Logout)(session.handle())).into_result() }
+    pub fn logout(&self) -> Result<()> {
+        unsafe { Rv::from(get_pkcs11!(self.client(), C_Logout)(self.handle())).into_result() }
     }
 }

--- a/pkcs11/src/new/types/session.rs
+++ b/pkcs11/src/new/types/session.rs
@@ -15,11 +15,15 @@ impl<'a> Session<'a> {
     pub(crate) fn handle(&self) -> CK_SESSION_HANDLE {
         self.handle
     }
+
+    pub(crate) fn client(&self) -> &Pkcs11 {
+        self.client
+    }
 }
 
 impl Drop for Session<'_> {
     fn drop(&mut self) {
-        if let Err(e) = self.client.close_session_private(self) {
+        if let Err(e) = self.close_private() {
             error!("Failed to close session: {}", e);
         }
     }

--- a/pkcs11/src/new/types/session.rs
+++ b/pkcs11/src/new/types/session.rs
@@ -5,11 +5,21 @@ use pkcs11_sys::*;
 pub struct Session<'a> {
     handle: CK_SESSION_HANDLE,
     client: &'a Pkcs11,
+    // This is not used but to prevent Session to automatically implement Send and Sync
+    _guard: *mut u32,
 }
+
+// Session does not implement Sync to prevent the same Session instance to be used from multiple
+// threads.
+unsafe impl<'a> Send for Session<'a> {}
 
 impl<'a> Session<'a> {
     pub(crate) fn new(handle: CK_SESSION_HANDLE, client: &'a Pkcs11) -> Self {
-        Session { handle, client }
+        Session {
+            handle,
+            client,
+            _guard: 0 as *mut u32,
+        }
     }
 
     pub(crate) fn handle(&self) -> CK_SESSION_HANDLE {


### PR DESCRIPTION
Also implements Drop on the Pkcs11 structure to finalize. That allows
making multiple Arc copies of Pkcs11 to send them to different threads
and finalize after.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>