### PR TITLE
Record logged in sessions for better usability

### DIFF
--- a/pkcs11-sys/Cargo.toml
+++ b/pkcs11-sys/Cargo.toml
@@ -19,9 +19,7 @@ include = [
 ]
 
 [build-dependencies]
-# NOTE: requires dynamic loading features for bindgen. This is not currently
-#       merged into `master`.
-bindgen = { git = "https://github.com/joechrisellis/rust-bindgen" }
+bindgen = "0.56.0"
 
 [dependencies]
 libloading = "0.6.3"

--- a/pkcs11/Cargo.toml
+++ b/pkcs11/Cargo.toml
@@ -39,6 +39,7 @@ libloading = "0.6.1"
 num-bigint = "0.2.6"
 pkcs11-sys = { path = "../pkcs11-sys" }
 log = "0.4.11"
+secrecy = "0.7.0"
 #libc = "0.2.33"
 
 [dev-dependencies]

--- a/pkcs11/src/new/types/function.rs
+++ b/pkcs11/src/new/types/function.rs
@@ -120,7 +120,7 @@ impl From<CK_RV> for Rv {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum RvError {
     Cancel,
     HostMemory,

--- a/pkcs11/src/new/types/mod.rs
+++ b/pkcs11/src/new/types/mod.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::ops::Deref;
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct Flags {
     flags: CK_FLAGS,
 }

--- a/pkcs11/src/new/types/slot_token.rs
+++ b/pkcs11/src/new/types/slot_token.rs
@@ -1,6 +1,6 @@
 use pkcs11_sys::CK_SLOT_ID;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Slot {
     slot_id: u64,
 }
@@ -12,5 +12,13 @@ impl Slot {
 
     pub fn id(&self) -> u64 {
         self.slot_id
+    }
+
+    /// It is sometimes useful to create a Slot instance from a specific slot ID. If the slot_id
+    /// does not correspond to any slot, methods using it will fail safely.
+    /// Prefer using the Slot and Token Management methods to be sure to have valid slots to work
+    /// with.
+    pub fn from_u64(slot_id: u64) -> Self {
+        Slot { slot_id }
     }
 }


### PR DESCRIPTION
Because sessions on a given token all share the login/logout state, a
logic layer is needed for applications not to fail loging in in the user
is already logged in and not to logout all sessions if there are still
sessions that needs the log in state.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>