### PR TITLE
Limit slot numbers to 32-bit

### DIFF
--- a/pkcs11/src/new/functions/session_management.rs
+++ b/pkcs11/src/new/functions/session_management.rs
@@ -15,7 +15,7 @@ impl Pkcs11 {
 
         unsafe {
             Rv::from(get_pkcs11!(self, C_OpenSession)(
-                slot_id.id(),
+                slot_id.into(),
                 flags.into(),
                 // TODO: abstract those types or create new functions for callbacks
                 std::ptr::null_mut(),

--- a/pkcs11/src/new/functions/slot_token_management.rs
+++ b/pkcs11/src/new/functions/slot_token_management.rs
@@ -85,7 +85,7 @@ impl Pkcs11 {
         let label = [b' '; 32];
         unsafe {
             Rv::from(get_pkcs11!(self, C_InitToken)(
-                slot.id(),
+                slot.into(),
                 pin.expose_secret().as_ptr() as *mut u8,
                 pin.expose_secret().len().try_into()?,
                 label.as_ptr() as *mut u8,

--- a/pkcs11/src/new/types/slot_token.rs
+++ b/pkcs11/src/new/types/slot_token.rs
@@ -1,11 +1,13 @@
 //! Slot and token types
 
+use crate::new::{Error, Result};
 use pkcs11_sys::CK_SLOT_ID;
+use std::convert::{TryFrom, TryInto};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Type identifying a slot
 pub struct Slot {
-    slot_id: u64,
+    slot_id: CK_SLOT_ID,
 }
 
 impl Slot {
@@ -15,14 +17,22 @@ impl Slot {
 
     /// Underlying ID used for a slot
     pub fn id(&self) -> u64 {
-        self.slot_id
+        self.slot_id as u64
     }
+}
 
-    /// It is sometimes useful to create a Slot instance from a specific slot ID. If the slot_id
-    /// does not correspond to any slot, methods using it will fail safely.
-    /// Prefer using the Slot and Token Management methods to be sure to have valid slots to work
-    /// with.
-    pub fn from_u64(slot_id: u64) -> Self {
-        Slot { slot_id }
+impl TryFrom<u64> for Slot {
+    type Error = Error;
+
+    fn try_from(slot_id: u64) -> Result<Self> {
+        Ok(Self {
+            slot_id: slot_id.try_into()?,
+        })
+    }
+}
+
+impl From<Slot> for CK_SLOT_ID {
+    fn from(slot: Slot) -> Self {
+        slot.slot_id
     }
 }


### PR DESCRIPTION
`CK_SLOT_ID` is only guaranteed to be at least 32 bits wide (e.g. on some ARM platforms). By restricting the public interface to 32 bits, no compile-time detections are needed on the user side.

This change is not backwards compatible. I'm happy to submit a PR for `parsec_service::providers::pkcs11::ProviderBuilder` which needs to store slot numbers as `u32`.